### PR TITLE
Acknowledge data sources

### DIFF
--- a/R/covid19.R
+++ b/R/covid19.R
@@ -6,7 +6,7 @@
 
 #######################################################################
 
-covid19.data <- function(case='aggregated', local.data=FALSE, debrief=FALSE) {
+covid19.data <- function(case='aggregated', local.data=FALSE, debrief=FALSE, acknowledge=FALSE) {
 #' function to read "live" data from reported covid19 cases
 #'
 #' @param  case  a string indicating the category of the data, possible values are:
@@ -24,6 +24,7 @@ covid19.data <- function(case='aggregated', local.data=FALSE, debrief=FALSE) {
 #'      "ts-Toronto"       :  data for the City of Toronto, ON - Canada
 #' @param  local.data  boolean flag to indicate whether the data will be read from the local repo, in case of connectivity issues or data integrity
 #' @param  debrief  boolean specifying whether information about the read data is going to be displayed in screen
+#' @param  acknowledge  boolean flag to indicate that the user acknowledges where the date is coming from.  If FALSE, display data acquisition messages.
 #'
 #' @return  a dataframe (or a list in the case of "ALL") with the daily worlwide indicated type of data per country/region/city
 #'
@@ -42,10 +43,10 @@ covid19.data <- function(case='aggregated', local.data=FALSE, debrief=FALSE) {
 
 	if (tolower(case) == "ts-toronto") {
 		# data from the the City of Toronto
-		return(covid19.Toronto.data(data.fmt="TS",local.data=local.data,debrief=debrief))
+		return(covid19.Toronto.data(data.fmt="TS",local.data=local.data,debrief=debrief,acknowledge=acknowledge))
 	} else {
 		# data coming from JHU
-		return(covid19.JHU.data(case,local.data,debrief))
+		return(covid19.JHU.data(case,local.data,debrief,acknowledge))
 	}
 }
 
@@ -66,7 +67,7 @@ debriefing <- function(data,debrief=TRUE) {
 ######################################################################
 
 
-covid19.JHU.data <- function(case='aggregated', local.data=FALSE, debrief=FALSE) {
+covid19.JHU.data <- function(case='aggregated', local.data=FALSE, debrief=FALSE, acknowledge=FALSE) {
 #' function to read "live" data as reported by JHU's CCSE repository
 #'
 #' @param  case  a string indicating the category of the data, possible values are:
@@ -84,6 +85,7 @@ covid19.JHU.data <- function(case='aggregated', local.data=FALSE, debrief=FALSE)
 #'	"Toronto"	:  data for the City of Toronto, ON - Canada
 #' @param  local.data  boolean flag to indicate whether the data will be read from the local repo, in case of connectivity issues or data integrity
 #' @param  debrief  boolean specifying whether information about the read data is going to be displayed in screen
+#' @param  acknowledge  boolean flag to indicate that the user acknowledges where the date is coming from.  If FALSE, display data acquisition messages.
 #'
 #' @return  a dataframe (or a list in the case of "ALL") with the daily worlwide indicated type of data per country/region/city
 #'
@@ -216,7 +218,7 @@ covid19.JHU.data <- function(case='aggregated', local.data=FALSE, debrief=FALSE)
 				"ts-confirmed-us","ts-deaths-us",
 				"ts-Toronto"
 				)
-	if (! tolower(case) %in% possible.cases) 
+	if (! tolower(case) %in% possible.cases)
 		stop("Unrecognized selection of case <",case,"> -- possible options are: ",paste(possible.cases,collapse=" "))
 
 
@@ -240,13 +242,16 @@ covid19.JHU.data <- function(case='aggregated', local.data=FALSE, debrief=FALSE)
 
 		# URL and filename
 		cases.URL <- cases
-
-		message("Data being read from JHU/CCSE repository")
-		header('~')
+    if (!acknowledge) {
+		  message("Data being read from JHU/CCSE repository")
+		  header('~')
+    }
 	} else {
 		covid19.pckg <- 'covid19.analytics'
-		message("Data being read from *local* repo in the '",covid19.pckg,"' package")
-		header('~')
+		if (!acknowledge) {
+		  message("Data being read from *local* repo in the '",covid19.pckg,"' package")
+		  header('~')
+		}
 
 		#LOCAL.repo <- "data/"
 		#print(system.file("extdata", "03-27-2020.csv", package = covid19.pckg))
@@ -275,9 +280,11 @@ covid19.JHU.data <- function(case='aggregated', local.data=FALSE, debrief=FALSE)
                 )
 
 		cases.URL <- cases
-        }
+  }
 
-	message("Reading data from ", cases)
+	if (!acknowledge) {
+	  message("Reading data from ", cases)
+	}
 
 	# Attempt to protect against bad internet conenction or misspelled package name
 	tryCatch( {
@@ -303,10 +310,12 @@ covid19.JHU.data <- function(case='aggregated', local.data=FALSE, debrief=FALSE)
 			t0 <- names(covid19.cases)[beginning.dates]
 			tf <- names(covid19.cases)[ncol(covid19.cases)]
 
-			message("Data retrieved on ",Sys.time()," || ",
-				"Range of dates on data: ",t0,"--",tf,
-				" | Nbr of records: ",nrow(covid19.cases))
-			header('-')
+			if (!acknowledge) {
+  			message("Data retrieved on ",Sys.time()," || ",
+  				"Range of dates on data: ",t0,"--",tf,
+  				" | Nbr of records: ",nrow(covid19.cases))
+  			header('-')
+			}
 
 			# check consistency of the data
 			#consistency.check(covid19.ts,datasetName=case,details=FALSE)
@@ -321,7 +330,7 @@ covid19.JHU.data <- function(case='aggregated', local.data=FALSE, debrief=FALSE)
 
 		return(covid19.cases)
 		},
-        
+
 		# warning
 		warning = function(cond) {
 				errorHandling.Msg(cond,cases.URL)
@@ -344,7 +353,7 @@ covid19.JHU.data <- function(case='aggregated', local.data=FALSE, debrief=FALSE)
 ###########################################################################
 
 
-covid19.Toronto.data <- function(data.fmt="TS",local.data=FALSE,debrief=FALSE, OLD.fmt=FALSE) {
+covid19.Toronto.data <- function(data.fmt="TS",local.data=FALSE,debrief=FALSE, OLD.fmt=FALSE, acknowledge=FALSE) {
 #' function to import data from the city of Toronto, ON - Canada
 #' as reported by the City of Toronto
 #'	https://www.toronto.ca/home/covid-19/covid-19-latest-city-of-toronto-news/covid-19-status-of-cases-in-toronto/
@@ -353,6 +362,7 @@ covid19.Toronto.data <- function(data.fmt="TS",local.data=FALSE,debrief=FALSE, O
 #' @param  local.data  boolean flag to indicate whether the data will be read from the local repo, in case of connectivity issues or data integrity
 #' @param  debrief  boolean specifying whether information about the read data is going to be displayed in screen
 #' @param  OLD.fmt  boolean flag to specify if the data is being read in an old format
+#' @param  acknowledge  boolean flag to indicate that the user acknowledges where the date is coming from.  If FALSE, display data acquisition messages.
 #'
 #' @return  a dataframe (or a list in the case of "original") with the latest data reported for the city of Toronto, ON - Canada
 #'
@@ -369,7 +379,9 @@ covid19.Toronto.data <- function(data.fmt="TS",local.data=FALSE,debrief=FALSE, O
 		city.of.Toronto.data <- "https://drive.google.com/uc?export=download&id=1euhrML0rkV_hHF1thiA0G5vSSeZCqxHY"
 		# temporary file to retrieve data, does not exist yet ==> mustwork=FALSE to avoid warning message
 		Tor.xlsx.file <- normalizePath(file.path(tempdir(), "covid19-toronto.xslx"), mustWork=FALSE)
-		header('',paste("Accessing file from...",Tor.xlsx.file))
+		if (!acknowledge) {
+		  header('',paste("Accessing file from...",Tor.xlsx.file))
+		}
 
 		# save excel file
 		#if (capabilities('libcurl')) {
@@ -381,9 +393,11 @@ covid19.Toronto.data <- function(data.fmt="TS",local.data=FALSE,debrief=FALSE, O
         } else {
                 # use local data
 		covid19.pckg <- 'covid19.analytics'
-                message("Data being read from *local* repo in the '",covid19.pckg,"' package")
-                header('~')
-                Tor.xlsx.file <- system.file("extdata","covid19_Toronto.xlsx", package=covid19.pckg, mustWork = TRUE)
+		if (!acknowledge) {
+  		message("Data being read from *local* repo in the '",covid19.pckg,"' package")
+      header('~')
+		}
+    Tor.xlsx.file <- system.file("extdata","covid19_Toronto.xlsx", package=covid19.pckg, mustWork = TRUE)
         }
 
 
@@ -402,10 +416,14 @@ covid19.Toronto.data <- function(data.fmt="TS",local.data=FALSE,debrief=FALSE, O
 
 		# read data
 		if (toupper(data.fmt)=="TS") {
-			header('',"Reading TimeSeries data...")
+		  if (!acknowledge) {
+		    header('',"Reading TimeSeries data...")
+		  }
 			toronto <- read_excel(Tor.xlsx.file,sheet=tgt.sheet)
 		} else {
-			header('',"Collecting all data reported...")
+		  if (!acknowledge) {
+		    header('',"Collecting all data reported...")
+		  }
 			toronto <- list()
 			# iterate on each sheet...
 			for (sht in lst.sheets) {
@@ -502,7 +520,7 @@ covid19.Toronto.data <- function(data.fmt="TS",local.data=FALSE,debrief=FALSE, O
 
 
 # wrapper function around the covid19.data() function
-covid19.US.data <- function(local.data=FALSE,debrief=FALSE) {
+covid19.US.data <- function(local.data=FALSE,debrief=FALSE,acknowledge=FALSE) {
 #' function to read the TimeSeries US detailed data
 #'
 #' @param  local.data  boolean flag to indicate whether the data will be read from the local repo, in case of connectivity issues or data integrity
@@ -514,16 +532,16 @@ covid19.US.data <- function(local.data=FALSE,debrief=FALSE) {
 #'
 
 	# read confirmed cases
-	US.conf <- covid19.data("ts-confirmed-US",local.data)
+	US.conf <- covid19.data("ts-confirmed-US",local.data,acknowledge=acknowledge)
 
 	# read deaths cases
-	US.deaths <- covid19.data("ts-deaths-US",local.data)
+	US.deaths <- covid19.data("ts-deaths-US",local.data,acknowledge=acknowledge)
 
 	# combine cases
 	US.cases <- rbind(US.conf,US.deaths)
 
         # debrief...
-        debriefing(US.cases,debrief) 
+        debriefing(US.cases,debrief)
 
 	return(US.cases)
 }

--- a/R/covid19.R
+++ b/R/covid19.R
@@ -392,13 +392,13 @@ covid19.Toronto.data <- function(data.fmt="TS",local.data=FALSE,debrief=FALSE, O
 		download.file(city.of.Toronto.data, destfile=Tor.xlsx.file, mode = 'wb' )	#method=dwnld.method)
         } else {
                 # use local data
-		covid19.pckg <- 'covid19.analytics'
-		if (!acknowledge) {
-  		message("Data being read from *local* repo in the '",covid19.pckg,"' package")
-      header('~')
-		}
-    Tor.xlsx.file <- system.file("extdata","covid19_Toronto.xlsx", package=covid19.pckg, mustWork = TRUE)
-        }
+  		covid19.pckg <- 'covid19.analytics'
+  		if (!acknowledge) {
+    		message("Data being read from *local* repo in the '",covid19.pckg,"' package")
+        header('~')
+  		}
+      Tor.xlsx.file <- system.file("extdata","covid19_Toronto.xlsx", package=covid19.pckg, mustWork = TRUE)
+    }
 
 
 	if (file.exists(Tor.xlsx.file)) {
@@ -525,6 +525,7 @@ covid19.US.data <- function(local.data=FALSE,debrief=FALSE,acknowledge=FALSE) {
 #'
 #' @param  local.data  boolean flag to indicate whether the data will be read from the local repo, in case of connectivity issues or data integrity
 #' @param  debrief  boolean specifying whether information about the read data is going to be displayed in screen
+#' @param  acknowledge  boolean flag to indicate that the user acknowledges where the date is coming from.  If FALSE, display data acquisition messages.
 #'
 #' @return  TimeSeries dataframe with data for the US
 #'

--- a/R/covid19.R
+++ b/R/covid19.R
@@ -24,7 +24,7 @@ covid19.data <- function(case='aggregated', local.data=FALSE, debrief=FALSE, ack
 #'      "ts-Toronto"       :  data for the City of Toronto, ON - Canada
 #' @param  local.data  boolean flag to indicate whether the data will be read from the local repo, in case of connectivity issues or data integrity
 #' @param  debrief  boolean specifying whether information about the read data is going to be displayed in screen
-#' @param  acknowledge  boolean flag to indicate that the user acknowledges where the date is coming from.  If FALSE, display data acquisition messages.
+#' @param  acknowledge  boolean flag to indicate that the user acknowledges where the data is coming from.  If FALSE, display data acquisition messages.
 #'
 #' @return  a dataframe (or a list in the case of "ALL") with the daily worlwide indicated type of data per country/region/city
 #'
@@ -85,7 +85,7 @@ covid19.JHU.data <- function(case='aggregated', local.data=FALSE, debrief=FALSE,
 #'	"Toronto"	:  data for the City of Toronto, ON - Canada
 #' @param  local.data  boolean flag to indicate whether the data will be read from the local repo, in case of connectivity issues or data integrity
 #' @param  debrief  boolean specifying whether information about the read data is going to be displayed in screen
-#' @param  acknowledge  boolean flag to indicate that the user acknowledges where the date is coming from.  If FALSE, display data acquisition messages.
+#' @param  acknowledge  boolean flag to indicate that the user acknowledges where the data is coming from.  If FALSE, display data acquisition messages.
 #'
 #' @return  a dataframe (or a list in the case of "ALL") with the daily worlwide indicated type of data per country/region/city
 #'
@@ -362,7 +362,7 @@ covid19.Toronto.data <- function(data.fmt="TS",local.data=FALSE,debrief=FALSE, O
 #' @param  local.data  boolean flag to indicate whether the data will be read from the local repo, in case of connectivity issues or data integrity
 #' @param  debrief  boolean specifying whether information about the read data is going to be displayed in screen
 #' @param  OLD.fmt  boolean flag to specify if the data is being read in an old format
-#' @param  acknowledge  boolean flag to indicate that the user acknowledges where the date is coming from.  If FALSE, display data acquisition messages.
+#' @param  acknowledge  boolean flag to indicate that the user acknowledges where the data is coming from.  If FALSE, display data acquisition messages.
 #'
 #' @return  a dataframe (or a list in the case of "original") with the latest data reported for the city of Toronto, ON - Canada
 #'
@@ -525,7 +525,7 @@ covid19.US.data <- function(local.data=FALSE,debrief=FALSE,acknowledge=FALSE) {
 #'
 #' @param  local.data  boolean flag to indicate whether the data will be read from the local repo, in case of connectivity issues or data integrity
 #' @param  debrief  boolean specifying whether information about the read data is going to be displayed in screen
-#' @param  acknowledge  boolean flag to indicate that the user acknowledges where the date is coming from.  If FALSE, display data acquisition messages.
+#' @param  acknowledge  boolean flag to indicate that the user acknowledges where the data is coming from.  If FALSE, display data acquisition messages.
 #'
 #' @return  TimeSeries dataframe with data for the US
 #'


### PR DESCRIPTION
Add some flags to suppress the message() and header() calls.

I made them non-default so that the changes are non-breaking.

This should help silence automated runs of scripts that use the library by allowing the users to pre-acknowledge the sources of the data before moving the scripts to production.  A silent script is helpful when automating with cron so that cron reports can be exceptional and prevent alert fatigue.